### PR TITLE
allow everyone with write access to bypass rules

### DIFF
--- a/otterdog/eclipse-lmos.jsonnet
+++ b/otterdog/eclipse-lmos.jsonnet
@@ -12,8 +12,7 @@ local defaultBranchRuleset() =
     },
     requires_linear_history: true,
     bypass_actors+: [
-      "@eclipse-lmos/technology-lmos-project-leads",
-      "@eclipse-lmos/technology-lmos-committers",
+      "#Write",
     ],
   };
 


### PR DESCRIPTION
I'm not 100% sure if thats the right way to do it, so feel free to point me to the right way....

I want to give the service account @eclipse-lmos-bot (which has a PAT stored in secrets.LMOS_BOT_TOKEN) access to push changes direct to main branch, which is protected and currently declines direct pushes from anyone.

The last change wasn't working right, so it was reverted, see comment here: https://github.com/eclipse-lmos/.eclipsefdn/pull/15#issuecomment-2710343312

I think with this change, all developers would get direct push rights too, which should create PR instead, but I'm not sure if that configuration is supported through otterdog.